### PR TITLE
Working on Iptables

### DIFF
--- a/openvpn.sh
+++ b/openvpn.sh
@@ -68,7 +68,7 @@ configure_default_rules() {
   ${IPT} -X
   # Default filter policy
   ${IPT} -P INPUT DROP
-  ${IPT} -P INPUT DROP
+  ${IPT} -P OUTPUT DROP
   ${IPT} -P FORWARD DROP
   # Accept on localhost
   ${IPT} -A INPUT -i lo -j ACCEPT

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -48,6 +48,7 @@ dns() {
 
 allow_only_vpn_dns () {
     local IPT=$1
+    # Will generate the hex string for DNS request in the form |03|www|06|google|03|com including zero padding
     remotes=$(egrep "^remote" $conf | awk '{print $2}' | awk -F '.' '{b=""}{
                 for (i=1;i<=NF;i++) {
                     h=sprintf("%x", length($1));


### PR DESCRIPTION
Working on locking down the iptables configuration to be safe by default - which isn't the case currently.

Original issues & pull requests:
dperson/openvpn-client#189
dperson/openvpn-client#192
dperson/openvpn-client#193

Tasks:
- [ ] Review the new iptables configuration - partially done in dperson/openvpn-client#189
- [ ] Define tests - does anyone know a free VPN service which we could use for automated tests?
- [ ] Set-up regular automated build to ensure upstream fixes are applied
- [ ] Figure out how we can provide this as replacement for the image on docker hub to provide a safe by default solution to all current users (do we need a switch for backward compatibility?)